### PR TITLE
Specify pull path to packer binary

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -79,6 +79,6 @@ fi
 export AWS_MAX_ATTEMPTS="120"
 export AWS_POLL_DELAY_SECONDS="60"
 
-packer build ${PACKER_TEMPLATE} | tee packer.log
+/usr/bin/packer build ${PACKER_TEMPLATE} | tee packer.log
 
 exit 0


### PR DESCRIPTION
RHEL8 contains a 'packer' binary on the PATH. Sans an absolute path, the build script was executing the RHEL packer which simply printed '0 0' and exited.