### PR TITLE
Switch to using an elastic IP address with the packer build to allow …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ packer.log
 *.log
 imageset-config.yaml.processed
 imageset-config.yaml.new
+cloud-config.sh

--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,7 @@ export AWS_DEFAULT_REGION=us-east-1
 . Run the packer build
 +
 ----
-OCP_VER=4.10.36 IMAGESET_CONFIG_TEMPLATE=imageset-config-templates/4.10-20221025.yaml PULL_SECRET=~/pull-secret.txt ./build.sh
+OCP_VER=4.10.36 IMAGESET_CONFIG_TEMPLATE=imageset-config-templates/4.10-20221025.yaml PULL_SECRET=~/pull-secret.txt EIP_ALLOC=eipalloc-abc123 ./build.sh
 ----
 
 [col=2*, separator=|]

--- a/aws-rhel8-quay.json
+++ b/aws-rhel8-quay.json
@@ -17,7 +17,10 @@
     "ocp_maj_ver": "{{env `OCP_MAJ_VER`}}",
     "ocp_min_ver": "{{env `OCP_MIN_VER`}}",
     "ocp_max_ver": "{{env `OCP_MAX_VER`}}",
-    "imageset_config_template": "{{env `IMAGESET_CONFIG_TEMPLATE`}}"
+    "imageset_config_template": "{{env `IMAGESET_CONFIG_TEMPLATE`}}",
+    "user_data_file": "{{env `USER_DATA_FILE`}}",
+    "ssh_host": "{{env `EIP_ADDRESS`}}",
+    "iam_instance_profile": "{{env `IAM_INSTANCE_PROFILE`}}"
   },
   "builders": [{
     "access_key": "{{user `aws_access_key`}}",
@@ -31,6 +34,9 @@
     "vpc_id": "{{ user `vpc_id` }}",
     "subnet_id": "{{ user `subnet_id` }}",
     "associate_public_ip_address": true,
+    "user_data_file": "{{ user `user_data_file` }}",
+    "iam_instance_profile": "{{ user `iam_instance_profile` }}",
+    "ssh_host": "{{ user `ssh_host` }}",
     "ami_virtualization_type": "hvm",
     "ami_block_device_mappings": [
       {

--- a/cloud-config.sh.template
+++ b/cloud-config.sh.template
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+touch /var/log/dan.log
+chmod 0644 /var/log/dan.log
+echo "Running cloud init with dan's ec2 commands" >> /var/log/dan.log
+
+# Need to install python and pip modules in the same way the bootstrap.yaml would do
+# for consistency. Need the awscli to associate the EIP address in cloud-init
+dnf -y install python38
+
+# Run these commands as the ec2-user since the build will install these
+# dependencies for the ec2-user as well which should save time and not install
+# them twice
+sudo -u ec2-user pip3 install --user --upgrade pip
+sudo -u ec2-user pip3 install --user --upgrade wheel
+sudo -u ec2-user pip3 install --user jinja2 awscli boto3 openshift jmespath packaging resolvelib
+
+export AWS_DEFAULT_REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region/)
+
+sudo AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} -u ec2-user /home/ec2-user/.local/bin/aws ec2 describe-instances \
+  --instance-ids $(curl -s "http://169.254.169.254/latest/meta-data/instance-id") 2>&1 | tee /var/log/dan.log
+
+sudo AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} -u ec2-user /home/ec2-user/.local/bin/aws ec2 associate-address \
+  --instance-id $(curl -s "http://169.254.169.254/latest/meta-data/instance-id") \
+  --allocation-id eipalloc-abc123 2>&1 | tee /var/log/dan.log
+
+exit 0

--- a/packer_iam.json
+++ b/packer_iam.json
@@ -1,0 +1,48 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AssociateAddress",
+        "ec2:AttachVolume",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CopyImage",
+        "ec2:CreateImage",
+        "ec2:CreateKeypair",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteKeyPair",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteSnapshot",
+        "ec2:DeleteVolume",
+        "ec2:DeregisterImage",
+        "ec2:DescribeImageAttribute",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeRegions",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcs",
+        "ec2:DetachVolume",
+        "ec2:GetPasswordData",
+        "ec2:ModifyImageAttribute",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifySnapshotAttribute",
+        "ec2:RegisterImage",
+        "ec2:RunInstances",
+        "ec2:StopInstances",
+        "ec2:TerminateInstances",
+        "iam:GetInstanceProfile",
+        "iam:PassRole"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
By default packer will use the public IP assigned to an EC2 instance which is random. This PR switches the build to use an AWS elastic IP address which is a static IP.

I've also updated to README to provide an example with the new EIP_ALLOC option.

Packer does not directly support using an elastic IP from AWS in the packer config json. Instead the instance user-data must perform the ec2 associate address API call.

This PR also includes a json template representing the minimum required IAM instance profile permissions needed for an instance to assign itself an elastic IP. The IAM instance profile can be specified on the command line as an option. The scripts/build do not create the IAM instance role or profile, these must be created first.