### PR TITLE
Add packer template and build script to create RHEL 8 STIG hardened AMI

### DIFF
--- a/aws-rhel8-template.json
+++ b/aws-rhel8-template.json
@@ -1,0 +1,150 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "username": "{{env `USERNAME`}}",
+    "region": "{{env `AWS_DEFAULT_REGION`}}",
+    "ami_description": "RHEL 8 hardened template image",
+    "purpose": "RHEL 8 base image with hardening applied for use with the quay mirror registry",
+    "os": "RHEL",
+    "os_version": "8",
+    "release": "8.7",
+    "vpc_id": "{{env `DEAFULT_VPC_ID`}}",
+    "subnet_id": "{{env `SUBNET_ID`}}",
+    "source_ami": "{{env `SOURCE_AMI`}}",
+    "pull_secret": "{{env `PULL_SECRET`}}",
+    "user_data_file": "{{env `USER_DATA_FILE`}}",
+    "ssh_host": "{{env `EIP_ADDRESS`}}",
+    "iam_instance_profile": "{{env `IAM_INSTANCE_PROFILE`}}"
+  },
+  "builders": [{
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "ami_name": "Quay Registry for OCP4 {{user `ocp_ver`}} {{isotime \"2006-01-02-150405\"}}",
+    "ami_description": "Quay Registry for OCP4 {{user `ocp_ver`}} {{isotime \"2006-01-02-150405\"}}",
+    "instance_type": "m5.xlarge",
+    "source_ami": "{{user `source_ami`}}",
+    "type": "amazon-ebs",
+    "region": "{{user `region`}}",
+    "vpc_id": "{{ user `vpc_id` }}",
+    "subnet_id": "{{ user `subnet_id` }}",
+    "associate_public_ip_address": true,
+    "user_data_file": "{{ user `user_data_file` }}",
+    "iam_instance_profile": "{{ user `iam_instance_profile` }}",
+    "ssh_host": "{{ user `ssh_host` }}",
+    "ami_virtualization_type": "hvm",
+    "ami_block_device_mappings": [
+      {
+        "device_name": "/dev/sda1",
+        "volume_size": 50,
+        "encrypted": false,
+        "volume_type": "gp2",
+        "delete_on_termination": true
+      }
+    ],
+    "launch_block_device_mappings": [
+      {
+        "device_name": "/dev/sda1",
+        "volume_size": 50,
+        "encrypted": false,
+        "volume_type": "gp2",
+        "delete_on_termination": true
+      }
+    ],
+    "ebs_optimized": true,
+    "ena_support": true,
+    "force_delete_snapshot": true,
+    "encrypt_boot": false,
+    "run_tags": {
+      "Creator": "{{user `username`}}",
+      "OS": "{{user `os`}}",
+      "OS_Version": "{{user `os_version`}}",
+      "Release": "{{user `release`}}",
+      "Base_AMI_Name": "{{ .SourceAMIName }}",
+      "Purpose": "{{user `purpose`}}",
+      "Builder": "Packer {{packer_version}}"
+    },
+    "run_volume_tags": {
+      "Creator": "{{user `username`}}",
+      "OS": "{{user `os`}}",
+      "OS_Version": "{{user `os_version`}}",
+      "Release": "{{user `release`}}",
+      "Base_AMI_Name": "{{ .SourceAMIName }}",
+      "Purpose": "{{user `purpose`}}",
+      "Builder": "Packer {{packer_version}}"
+    },
+    "tags": {
+      "Creator": "{{user `username`}}",
+      "OS": "{{user `os`}}",
+      "OS_Version": "{{user `os_version`}}",
+      "Release": "{{user `release`}}",
+      "Base_AMI_Name": "{{ .SourceAMIName }}",
+      "Purpose": "{{user `purpose`}}",
+      "Builder": "Packer {{packer_version}}"
+    },
+    "snapshot_tags": {
+      "Creator": "{{user `username`}}",
+      "OS": "{{user `os`}}",
+      "OS_Version": "{{user `os_version`}}",
+      "Release": "{{user `release`}}",
+      "Base_AMI_Name": "{{ .SourceAMIName }}",
+      "Purpose": "{{user `purpose`}}",
+      "Builder": "Packer {{packer_version}}"
+    },
+    "ssh_username": "ec2-user",
+    "ssh_pty": "true"
+  }],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "playbooks",
+      "destination": "/home/ec2-user"
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo -n sh '{{.Path}}'",
+      "inline": [
+        "echo '*** Installing updates...'",
+        "dnf -y update",
+        "echo '*** Installing Base Dependencies...'",
+        "dnf -y install ansible-core python38"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "echo '*** Installing User Space Dependencies...'",
+        "set -ex",
+        "pip3 install --user --upgrade pip",
+        "pip3 install --user --upgrade wheel",
+        "pip3 install --user jinja2 jmespath",
+        "ansible-galaxy role install --force redhatofficial.rhel8_stig",
+        "ansible-galaxy collection install --upgrade community.crypto community.general ansible.posix"
+      ]
+    },
+    {
+      "type": "shell",
+      "execute_command": "/bin/sh -c {{ .Path }} {{ .Vars }}",
+      "inline": [
+        "echo '*** Applying RHEL 8 STIG Hardening...'",
+        "set -ex",
+        "ansible-playbook /home/ec2-user/playbooks/harden_quay.yaml"
+      ]
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo -n sh '{{.Path}}'",
+      "inline": [
+        "echo '** Shreding sensitive data ...'",
+        "dnf clean all",
+        "rm -rf /var/cache/yum /var/cache/dnf",
+        "rm -rf /home/ec2-user/playbooks",
+        "shred -u /etc/ssh/*_key /etc/ssh/*_key.pub",
+        "shred -u /root/.*history /home/*/.*history",
+        "shred -u /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys",
+        "sync; sleep 1; sync"
+      ]
+    }
+  ]
+}
+

--- a/build_template.sh
+++ b/build_template.sh
@@ -1,0 +1,83 @@
+#!/bin/bash -e
+
+export PACKER_TEMPLATE="aws-rhel8-template.json"
+
+# Use zone c for builds. Change to a different zone for your region if needed
+export AWS_ZONE="${AWS_ZONE:-c}"
+
+# Red Hat Account ID in AWS for AMI search
+export REDHAT_ID="${REDHAT_ID:-309956199498}"
+
+# Current RHEL version to build with
+export RHEL_VER="${RHEL_VER:-8.7}"
+
+# AWS EIP Configuration
+export USER_DATA_FILE="cloud-config.sh"
+# Example AWS EIP allocation ID
+#export EIP_ALLOC=eipalloc-abc123
+
+# The IAM instance profile needs to have permissions to associate an EIP with an instance
+export IAM_INSTANCE_PROFILE="${IAM_INSTANCE_PROFILE:-packer}"
+
+if [ -z $AWS_ACCESS_KEY_ID ];
+then
+  echo "AWS_ACCESS_KEY_ID Required"
+  exit 1
+fi
+
+if [ -z $AWS_SECRET_ACCESS_KEY ];
+then
+  echo "AWS_SECRET_ACCESS_KEY Required"
+  exit 1
+fi
+
+if [ -z $AWS_DEFAULT_REGION ];
+then
+  echo "AWS_DEFAULT_REGION Required"
+  exit 1
+fi
+
+if [ -z $EIP_ALLOC ];
+then
+  echo "EIP_ALLOC Required"
+  exit 1
+fi
+
+# Obtain the IP address associated with the EIP Allocation ID
+echo "Get EIP Address"
+export EIP_ADDRESS=$(aws ec2 describe-addresses --allocation-ids ${EIP_ALLOC} | jq -r '.Addresses[0].PublicIp')
+rm -f cloud-config.sh
+sed "s|eipalloc-abc123|${EIP_ALLOC}|g" cloud-config.sh.template > cloud-config.sh
+chmod 0755 cloud-config.sh
+
+if [ -z $DEFAULT_VPC_ID ];
+then
+  # Get default VPC ID
+  export DEFAULT_VPC_ID=$(aws ec2 describe-vpcs \
+    --query 'Vpcs[?IsDefault == `true`].VpcId' \
+    --output text)
+fi
+
+if [ -z $SUBNET_ID ];
+then
+  # Get subnet ID for az ${AWS_ZONE} in region ${AWS_DEFAULT_REGION}
+  export SUBNET_ID=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=${DEFAULT_VPC_ID}" \
+    --query "Subnets[?AvailabilityZone == '${AWS_DEFAULT_REGION}${AWS_ZONE}'].SubnetId" \
+    --output text)
+fi
+
+if [ -z $SOURCE_AMI ];
+then
+  export SOURCE_AMI=$(aws ec2 describe-images --owners ${REDHAT_ID} --region ${AWS_DEFAULT_REGION} \
+    --output text --query 'Images[*].[ImageId]' \
+    --filters "Name=name,Values=RHEL-${RHEL_VER}?*HVM-*Hourly*" Name=architecture,Values=x86_64 | sort -r | head -1)
+fi
+
+# Need to set these values or packer can timeout due to how long
+# it can take for the AMI to become ready in the AWS API/Console
+export AWS_MAX_ATTEMPTS="240"
+export AWS_POLL_DELAY_SECONDS="30"
+
+packer build ${PACKER_TEMPLATE} | tee packer_template.log
+
+exit 0

--- a/playbooks/harden_quay.yaml
+++ b/playbooks/harden_quay.yaml
@@ -24,3 +24,16 @@
         accounts_password_minlen_login_defs: false
         require_emergency_target_auth: false
         require_singleuser_auth: false
+        accounts_minimum_age_login_defs: false
+        accounts_maximum_age_login_defs: false
+        accounts_logon_fail_delay: false
+        sshd_disable_root_login: false
+
+  tasks:
+
+      # Create file to indicate hardening has been completed
+    - name: Touch file to indicate hardening has been done
+      ansible.builtin.file:
+        path: /etc/sysconfig/rh-quay-hardened
+        state: touch
+        mode: u=rw,g=r,o=r


### PR DESCRIPTION
Add packer template and build script to create RHEL 8 STIG hardened AMI for use with quay image build. The hardening playbook takes about 45 minutes to run on a RHEL 8 host. By creating a hardening template to use with the quay image building packer template we can reduce the build time by almost an hour.