### PR TITLE
Switch build process to install quay and mirror from local tar archive at initial AMI launch in target environment

### DIFF
--- a/aws-rhel8-quay.json
+++ b/aws-rhel8-quay.json
@@ -122,6 +122,11 @@
     },
     {
       "type": "file",
+      "source": "quayinit.sh",
+      "destination": "/tmp/quayinit.sh"
+    },
+    {
+      "type": "file",
       "source": "update_mirror_metadata.sh",
       "destination": "/tmp/update_mirror_metadata.sh"
     },
@@ -167,12 +172,12 @@
         "set -ex",
         "ansible-galaxy collection install containers.podman",
         "mv /tmp/quayinit.service /etc/systemd/system/quayinit.service",
+        "mv /tmp/quayinit.sh /usr/bin/quayinit.sh",
         "chmod 0644 /etc/systemd/system/quayinit.service",
-        "restorecon -v /etc/systemd/system/quayinit.service",
+        "chmod 0755 /usr/bin/quayinit.sh",
+        "restorecon -v /etc/systemd/system/quayinit.service /usr/bin/quayinit.sh",
         "systemctl daemon-reload",
-        "systemctl enable quayinit.service",
-        "/usr/local/bin/mirror-registry install --verbose --quayRoot /opt/quay/ | tee /var/log/mirror-registry.log",
-        "chmod 0644 /var/log/mirror-registry.log"
+        "systemctl enable quayinit.service"
       ]
     },
     {
@@ -183,20 +188,15 @@
         "set -ex",
         "mkdir -p ${XDG_RUNTIME_DIR}/containers || true",
         "cat /tmp/pull-secret.txt > ${XDG_RUNTIME_DIR}/containers/auth.json",
-        "export REG_USER=$(grep -o '(.*, .*)' /var/log/mirror-registry.log | sed 's|[(),]||g' | awk '{print $1}')",
-        "export REG_PASS=$(grep -o '(.*, .*)' /var/log/mirror-registry.log | sed 's|[(),]||g' | awk '{print $2}')",
-        "podman login --authfile=${HOME}/pull-secret.txt -u=${REG_USER} -p=${REG_PASS} --tls-verify=false ${HOSTNAME}:8443",
-        "podman login -u=${REG_USER} -p=${REG_PASS} --tls-verify=false ${HOSTNAME}:8443",
-        "ansible-playbook /home/ec2-user/playbooks/harden_quay.yaml",
-        "/usr/local/bin/oc-mirror --config /home/ec2-user/imageset-config.yaml --dest-skip-tls --continue-on-error docker://${HOSTNAME}:8443 || true"
+        "echo 'Run hardening playbook if AMI has not already been hardened'",
+        "if [ ! -e /etc/sysconfig/rh-quay-hardened ]; then ansible-playbook /home/ec2-user/playbooks/harden_quay.yaml; fi",
+        "/usr/local/bin/oc-mirror --config /home/ec2-user/imageset-config.yaml --continue-on-error file://archives || true"
       ]
     },
     {
       "type": "shell",
       "execute_command": "/bin/sh -c {{ .Path }} {{ .Vars }}",
       "inline": [
-        "echo '*** Updating Mirroring Content Metadata...'",
-        "bash /tmp/update_mirror_metadata.sh",
         "echo '*** Extracting ccoctl binary from release image...'",
         "bash /tmp/get_ccoctl.sh"
       ]

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -4,7 +4,7 @@
   gather_facts: true
   connection: local
   vars:
-    dev_uri: "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients"
+    dev_uri: "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients"
     mirror_uri: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients"
     ocp_maj_ver: "4.11"   # Overridden in the packer build
     ocp_min_ver: "4.11.8" # Overridden in the packer build
@@ -12,6 +12,7 @@
     quay_root: /opt/quay
     reg_user: "init"
     reg_pass: "openshift"
+    oc_mirror_dir: "/opt/openshift/mirror"
 
   tasks:
 
@@ -25,13 +26,6 @@
       ansible.builtin.dnf:
         name: "*"
         state: latest
-
-#    - name: Update pip
-#      become: true
-#      ansible.builtin.pip:
-#        name: pip
-#        state: latest
-#        executable: pip3
 
     - name: Install container-tools module
       become: true
@@ -71,7 +65,7 @@
         dest: /usr/local/bin
         remote_src: true
       loop:
-        - "{{ dev_uri }}/mirror-registry/1.2.6/mirror-registry.tar.gz"
+        - "{{ dev_uri }}/mirror-registry/latest/mirror-registry.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-install-linux-{{ ocp_max_ver }}.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-client-linux-{{ ocp_max_ver }}.tar.gz"
         - "{{ mirror_uri }}/ocp/latest-4.11/oc-mirror.tar.gz"
@@ -85,7 +79,7 @@
         dest: /usr/local/bin/odo
         mode: '0755'
       loop:
-        - "{{ dev_uri }}/odo/v2.5.1/odo-linux-amd64"
+        - "{{ dev_uri }}/odo/latest/odo-linux-amd64"
 
     - name: Create clients directory
       become: true
@@ -101,7 +95,7 @@
         url: "{{ item }}"
         dest: /opt/openshift/clients/
       loop:
-        - "{{ dev_uri }}/mirror-registry/1.2.6/mirror-registry.tar.gz"
+        - "{{ dev_uri }}/mirror-registry/latest/mirror-registry.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-install-linux-{{ ocp_max_ver }}.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-client-linux-{{ ocp_max_ver }}.tar.gz"
         - "{{ mirror_uri }}/ocp/latest-4.11/oc-mirror.tar.gz"
@@ -144,45 +138,6 @@
         path: "{{ quay_root }}"
         state: directory
 
-#    - name: Remove existing quay certs from system trust store
-#      become: true
-#      file:
-#        path: /etc/pki/ca-trust/source/anchors/quay.cert
-#        state: absent
-#
-#    - name: Copy quay cert to system trust store
-#      become: true
-#      copy:
-#        src: /opt/quay/quay-config/ssl.cert
-#        dest: /etc/pki/ca-trust/source/anchors/quay.cert
-#        remote_src: true
-#        owner: root
-#        group: root
-#        mode: 0644
-#
-#    - name: Update system trust store
-#      become: true
-#      ansible.builtin.command: update-ca-trust
-#
-#    - name: Extract system trust store
-#      become: true
-#      ansible.builtin.command: update-ca-trust extract
-#
-#    - name: Cleanup files
-#      become: true
-#      file:
-#        path: "{{ item }}"
-#        state: absent
-#      loop:
-#        - README.md
-#        - LICENSE
-#        - execution-environment.tar
-#        - image-archive.tar
-#        - pause.tar
-#        - postgres.tar
-#        - quay.tar
-#        - redis.tar
-
     - name: Create directory for git clone
       file:
         path: "{{ ansible_env.HOME }}/openshift4-c2s"
@@ -192,16 +147,6 @@
       ansible.builtin.git:
         repo: https://github.com/RedHatGov/openshift4-c2s.git
         dest: "{{ ansible_env.HOME }}/openshift4-c2s"
-
-#    - name: Install pip modules
-#      ansible.builtin.pip:
-#        name:
-#          - "wheel"
-#          - "jinja2"
-#          - "awscli"
-#          - "boto3"
-#        executable: pip3
-#        extra_args: "--user"
 
     - name: Create containers directory
       file:
@@ -213,40 +158,6 @@
         src: "/tmp/pull-secret.txt"
         dest: "{{ ansible_env.XDG_RUNTIME_DIR }}/containers/auth.json"
         remote_src: true
-
-    - name: Get Registry Username
-      shell: |
-        grep -o '(.*, .*)' /var/log/mirror-registry.log | sed 's|[(),]||g' | awk '{print $1}'
-      register: reg_user_info
-
-    - name: Get Registry Password
-      shell: |
-        grep -o '(.*, .*)' /var/log/mirror-registry.log | sed 's|[(),]||g' | awk '{print $1}'
-      register: reg_pass_info
-
-    - name: Set registry username and password facts
-      set_fact:
-        reg_user: "{{ reg_user_info.stdout }}"
-        reg_pass: "{{ reg_pass_info.stdout }}"
-
-    # The ansible_env.HOSTNAME doesn't get set for some reason
-    - name: Get hostname
-      ansible.builtin.command: hostname
-      register: hostname_info
-
-    - name: Set hostname fact
-      set_fact:
-        my_hostname: "{{ hostname_info.stdout }}"
-
-    - name: Show hostname var
-      debug:
-        var: my_hostname
-
-    - name: Replace localhost with actual hostname
-      ansible.builtin.replace:
-        path: /home/ec2-user/imageset-config.yaml
-        regexp: localhost
-        replace: "{{ my_hostname }}"
 
     - name: Replace OCP_MAJ_VER with actual version number
       ansible.builtin.replace:
@@ -265,3 +176,14 @@
         path: /home/ec2-user/imageset-config.yaml
         regexp: OCP_MAX_VER
         replace: "{{ ocp_max_ver }}"
+
+    - name: Create directory for oc-mirror images
+      file:
+        path: "{{ oc_mirror_dir }}"
+        state: directory
+
+    - name: Replace DATA_TMP with actual directory for mirror
+      ansible.builtin.replace:
+        path: /home/ec2-user/imageset-config.yaml
+        regexp: DATA_TMP
+        replace: "{{ oc_mirror_dir }}"

--- a/cloud-config.sh.template
+++ b/cloud-config.sh.template
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-touch /var/log/dan.log
-chmod 0644 /var/log/dan.log
-echo "Running cloud init with dan's ec2 commands" >> /var/log/dan.log
+LOG="/var/log/packer_init.log"
+touch "${LOG}"
+chmod 0644 "${LOG}"
+echo "Running cloud init to attach AWS EIP" >> "${LOG}"
+
+# Hardening is causing this to be an issue
+# TODO: Find hardening rule that causes this issue
+chage -M 99999 root
 
 # Need to install python and pip modules in the same way the bootstrap.yaml would do
 # for consistency. Need the awscli to associate the EIP address in cloud-init
@@ -13,15 +18,15 @@ dnf -y install python38
 # them twice
 sudo -u ec2-user pip3 install --user --upgrade pip
 sudo -u ec2-user pip3 install --user --upgrade wheel
-sudo -u ec2-user pip3 install --user jinja2 awscli boto3 openshift jmespath packaging resolvelib
+sudo -u ec2-user pip3 install --user --upgrade jinja2 awscli boto3 openshift jmespath packaging resolvelib
 
 export AWS_DEFAULT_REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region/)
 
 sudo AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} -u ec2-user /home/ec2-user/.local/bin/aws ec2 describe-instances \
-  --instance-ids $(curl -s "http://169.254.169.254/latest/meta-data/instance-id") 2>&1 | tee /var/log/dan.log
+  --instance-ids $(curl -s "http://169.254.169.254/latest/meta-data/instance-id") 2>&1 | tee -a "${LOG}"
 
 sudo AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} -u ec2-user /home/ec2-user/.local/bin/aws ec2 associate-address \
   --instance-id $(curl -s "http://169.254.169.254/latest/meta-data/instance-id") \
-  --allocation-id eipalloc-abc123 2>&1 | tee /var/log/dan.log
+  --allocation-id eipalloc-abc123 2>&1 | tee -a "${LOG}"
 
 exit 0

--- a/quayinit.service
+++ b/quayinit.service
@@ -2,16 +2,11 @@
 Description=Configure Quay on FirstBoot
 Wants=network.target
 After=network-online.target
-Before=quay-pod.service
-Before=quay-app.service
-Before=quay-redis.service
-Before=quay-postgres.service
-Before=systemd-user-sessions.service
 ConditionPathExists=!/etc/sysconfig/rh-quay-firstboot
 
 [Service]
 Type=oneshot
-ExecStart=ansible-playbook --connection=local --extra-vars 'launched_by_systemd=true' /home/ec2-user/playbooks/firstboot.yaml
+ExecStart=/usr/bin/quayinit.sh
 
 [Install]
 WantedBy=multi-user.target default.target

--- a/quayinit.sh
+++ b/quayinit.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -xe
+
+LOG_FILE="/var/log/mirror-registry.log"
+
+echo "Starting the quay firstboot script" >> "${LOG_FILE}"
+date >> "${LOG_FILE}"
+chmod 0644 "${LOG_FILE}"
+
+echo "Installing quay mirror registry" >> "${LOG_FILE}"
+
+# Set the HOME env var missing in systemd
+export HOME="/root"
+export USER="root"
+
+/usr/local/bin/mirror-registry install --verbose --quayRoot /opt/quay/ | tee -a "${LOG_FILE}"
+
+# Remove any existing quay certificate
+rm -f /etc/pki/ca-trust/source/anchors/quay.cert
+# Import quay certificate generated during install
+cp -f /opt/quay/quay-config/ssl.cert /etc/pki/ca-trust/source/anchors/quay.cert
+chown root.root /etc/pki/ca-trust/source/anchors/quay.cert
+chmod 0444 /etc/pki/ca-trust/source/anchors/quay.cert
+restorecon -v /etc/pki/ca-trust/source/anchors/quay.cert
+update-ca-trust
+update-ca-trust extract
+
+# extract the random username and password created by the quay mirror registry installer
+export REG_USER=$(grep -o '(.*, .*)' "${LOG_FILE}" | sed 's|[(),]||g' | awk '{print $1}')
+export REG_PASS=$(grep -o '(.*, .*)' "${LOG_FILE}" | sed 's|[(),]||g' | awk '{print $2}')
+
+# Create a local copy of the auth file for the ec2-user
+podman login --authfile=/home/ec2-user/pull-secret.txt -u=${REG_USER} -p=${REG_PASS} ${HOSTNAME}:8443
+chown ec2-user.ec2-user /home/ec2-user/pull-secret.txt
+chmod 0644 /home/ec2-user/pull-secret.txt
+
+# Login to local quay registry
+mkdir ${HOME}/.docker || true
+podman login --authfile=${HOME}/.docker/config.json -u=${REG_USER} -p=${REG_PASS} ${HOSTNAME}:8443
+
+date >> "${LOG_FILE}"
+
+echo "Importing local content archive into quay mirror registry" >> "${LOG_FILE}"
+
+/usr/local/bin/oc-mirror --from /home/ec2-user/archives/mirror_seq1_000000.tar docker://${HOSTNAME}:8443 | tee -a "${LOG_FILE}"
+
+date >> "${LOG_FILE}"
+
+# Ensure quay init does not run again
+touch /etc/sysconfig/rh-quay-firstboot
+
+exit 0


### PR DESCRIPTION
Switch build process to install quay and mirror from local tar archive at initial AMI launch in target environment.

Originally the packer build would install and run the quay mirror registry during packer build time and then mirror container images directly to the running quay instance from the internet.

With this model, the container images are mirrored to disk as a tar archive during the packer build.
When the AMI is launched in the target environment, the quay mirror registry is installer and started, along with the container images being mirrored from a local tar archive into the now running local quay registry.

The container image mirror tar archive file remains on the destination system to allow users to mirror the content to another location if needed.