### PR TITLE
Switch tooling repo to official openshift org repo

### DIFF
--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -145,7 +145,7 @@
 
     - name: Read-write git checkout from github
       ansible.builtin.git:
-        repo: https://github.com/RedHatGov/openshift4-c2s.git
+        repo: https://github.com/openshift/c2s-install.git
         dest: "{{ ansible_env.HOME }}/openshift4-c2s"
 
     - name: Create containers directory


### PR DESCRIPTION
openshift4-c2s repo has moved from RedHatGov org to the openshift org. Update quay image builder to use the new official repo location.