### PR TITLE
Update build to connect with RHN CDN using PEM file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ packer.log
 imageset-config.yaml.processed
 imageset-config.yaml.new
 cloud-config.sh
+rh-cdn.pem
+*.pem

--- a/aws-rhel8-quay.json
+++ b/aws-rhel8-quay.json
@@ -136,27 +136,6 @@
       "destination": "/tmp/get_ccoctl.sh"
     },
     {
-      "type": "shell",
-      "execute_command": "sudo -n sh '{{.Path}}'",
-      "inline": [
-        "echo '*** Installing Base Dependencies...'",
-        "set -ex",
-        "dnf -y install ansible-core python38"
-      ]
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "echo '*** Installing User Space Dependencies...'",
-        "set -ex",
-        "ansible-galaxy role install --force redhatofficial.rhel8_stig",
-        "pip3 install --user --upgrade pip",
-        "pip3 install --user --upgrade wheel",
-        "pip3 install --user jinja2 awscli boto3 openshift jmespath packaging resolvelib",
-        "ansible-galaxy collection install --upgrade amazon.aws community.aws community.crypto containers.podman community.general ansible.posix community.kubernetes"
-      ]
-    },
-    {
       "type": "ansible-local",
       "playbook_file": "./bootstrap.yaml",
       "extra_arguments": [
@@ -170,7 +149,6 @@
       "inline": [
         "echo '*** Installing Mirror Registry...'",
         "set -ex",
-        "ansible-galaxy collection install containers.podman",
         "mv /tmp/quayinit.service /etc/systemd/system/quayinit.service",
         "mv /tmp/quayinit.sh /usr/bin/quayinit.sh",
         "chmod 0644 /etc/systemd/system/quayinit.service",
@@ -208,11 +186,13 @@
         "echo '** Shreding sensitive data ...'",
         "dnf clean all",
         "rm -rf /var/cache/yum /var/cache/dnf",
-        "shred -u /etc/ssh/*_key /etc/ssh/*_key.pub",
-        "shred -u /root/.*history /home/*/.*history",
-        "shred -u /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys",
-        "shred -u /tmp/pull-secret.txt",
-        "shred -u /var/run/user/1000/containers/auth.json",
+        "shred -uf /tmp/key/rh-cdn.pem",
+        "shred -uf /etc/yum.repos.d/quay_image.repo",
+        "shred -uf /etc/ssh/*_key /etc/ssh/*_key.pub",
+        "shred -uf /root/.*history /home/*/.*history",
+        "shred -uf /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys",
+        "shred -uf /tmp/pull-secret.txt",
+        "shred -uf /var/run/user/1000/containers/auth.json",
         "sync; sleep 1; sync"
       ]
     }

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -145,7 +145,7 @@
 
     - name: Read-write git checkout from github
       ansible.builtin.git:
-        repo: https://github.com/RedHatGov/openshift4-c2s.git
+        repo: https://github.com/openshift/c2s-install.git
         dest: "{{ ansible_env.HOME }}/openshift4-c2s"
 
     - name: Create containers directory

--- a/build.sh
+++ b/build.sh
@@ -68,8 +68,12 @@ fi
 # Obtain the IP address associated with the EIP Allocation ID
 echo "Get EIP Address"
 export EIP_ADDRESS=$(aws ec2 describe-addresses --allocation-ids ${EIP_ALLOC} | jq -r '.Addresses[0].PublicIp')
-rm -f cloud-config.sh
-sed "s|eipalloc-abc123|${EIP_ALLOC}|g" cloud-config.sh.template > cloud-config.sh
+rm -f "${USER_DATA_FILE}"
+sed "s|eipalloc-abc123|${EIP_ALLOC}|g" cloud-config.sh.template > "${USER_DATA_FILE}"
+sed -e '/CDN_PEM_CONTENT/ {' -e 'r rh-cdn.pem' -e 'd' -e '}' -i "${USER_DATA_FILE}"
+sed -e '/YUM_REPO_CONTENT/ {' -e 'r quay_image.repo' -e 'd' -e '}' -i "${USER_DATA_FILE}"
+sed -i "s|OCP_MAJ_VER|${OCP_MAJ_VER}|g" "${USER_DATA_FILE}"
+
 chmod 0755 cloud-config.sh
 
 if [ -z $DEFAULT_VPC_ID ];

--- a/cloud-config.sh.template
+++ b/cloud-config.sh.template
@@ -5,28 +5,59 @@ touch "${LOG}"
 chmod 0644 "${LOG}"
 echo "Running cloud init to attach AWS EIP" >> "${LOG}"
 
+{
 # Hardening is causing this to be an issue
 # TODO: Find hardening rule that causes this issue
 chage -M 99999 root
 
+sudo sed -i 's|enabled=1|enabled=0|g' /etc/yum.repos.d/*.repo
+
+sudo mkdir /tmp/key
+cat << 'EOF' > /tmp/rh-cdn.pem
+CDN_PEM_CONTENT
+EOF
+
+sudo mv /tmp/rh-cdn.pem /tmp/key/rh-cdn.pem
+sudo chmod 0755 /tmp/key
+sudo chown root.root /tmp/key/rh-cdn.pem
+sudo chmod 0644 /tmp/key/rh-cdn.pem
+sudo restorecon -v /tmp/key/rh-cdn.pem
+
+cat << 'EOF' > /tmp/quay_image.repo
+YUM_REPO_CONTENT
+EOF
+
+sudo mv /tmp/quay_image.repo /etc/yum.repos.d/quay_image.repo
+sudo chown root.root /etc/yum.repos.d/quay_image.repo
+sudo chmod 0644 /etc/yum.repos.d/quay_image.repo
+sudo restorecon -v /etc/yum.repos.d/quay_image.repo
+
 # Need to install python and pip modules in the same way the bootstrap.yaml would do
 # for consistency. Need the awscli to associate the EIP address in cloud-init
-dnf -y install python38
+dnf -y install ansible-core python39
 
+echo '*** Installing Base Dependencies... ***'
 # Run these commands as the ec2-user since the build will install these
 # dependencies for the ec2-user as well which should save time and not install
 # them twice
 sudo -u ec2-user pip3 install --user --upgrade pip
 sudo -u ec2-user pip3 install --user --upgrade wheel
 sudo -u ec2-user pip3 install --user --upgrade jinja2 awscli boto3 openshift jmespath packaging resolvelib
+sudo -u ec2-user ansible-galaxy collection install --upgrade amazon.aws community.aws community.crypto containers.podman community.general ansible.posix community.kubernetes
+sudo -u ec2-user ansible-galaxy role install --force redhatofficial.rhel8_stig
 
+echo '*** Associating Elastic IP Address with instance... ***'
+# Determine what region the instance is in
 export AWS_DEFAULT_REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region/)
 
+# Determine instance ID
 sudo AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} -u ec2-user /home/ec2-user/.local/bin/aws ec2 describe-instances \
   --instance-ids $(curl -s "http://169.254.169.254/latest/meta-data/instance-id") 2>&1 | tee -a "${LOG}"
 
+# Associate Elastic IP Address with the instance
 sudo AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} -u ec2-user /home/ec2-user/.local/bin/aws ec2 associate-address \
   --instance-id $(curl -s "http://169.254.169.254/latest/meta-data/instance-id") \
   --allocation-id eipalloc-abc123 2>&1 | tee -a "${LOG}"
+} 2>&1 >> "${LOG}"
 
 exit 0

--- a/quay_image.repo
+++ b/quay_image.repo
@@ -1,0 +1,39 @@
+[rhel-8-for-x86_64-baseos-rpms]
+name = Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/$releasever/x86_64/baseos/os
+enabled = 1
+gpgcheck = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 0
+sslclientkey = /tmp/key/rh-cdn.pem
+sslclientcert = /tmp/key/rh-cdn.pem
+
+[rhel-8-for-x86_64-appstream-rpms]
+name = Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel8/$releasever/x86_64/appstream/os
+enabled = 1
+gpgcheck = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 0
+sslclientkey = /tmp/key/rh-cdn.pem
+sslclientcert = /tmp/key/rh-cdn.pem
+
+[rhocp-OCP_MAJ_VER-for-rhel-8-x86_64-rpms]
+name = Red Hat OpenShift Container Platform OCP_MAJ_VER for RHEL 8 x86_64 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/rhocp/OCP_MAJ_VER/os
+enabled = 1
+gpgcheck = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 0
+sslclientkey = /tmp/key/rh-cdn.pem
+sslclientcert = /tmp/key/rh-cdn.pem
+
+[ansible-2-for-rhel-8-x86_64-rpms]
+name = Red Hat Ansible Engine 2 for RHEL 8 x86_64 (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os
+enabled = 1
+gpgcheck = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 0
+sslclientkey = /tmp/key/rh-cdn.pem
+sslclientcert = /tmp/key/rh-cdn.pem


### PR DESCRIPTION
Because the build requires the use of an Elastic IP to maintain a static IP address between each build, and allocating the Elastic IP address in packer requires using the aws CLI within the cloud-init script of the AMI, this looks a bit ugly.

Everything has to be done in the cloud init script to enable subscriptions with the PEM, install dependencies, and then attach the EIP.