### PR TITLE
Shred cloud init after install to remove PEM contents

### DIFF
--- a/cloud-config.sh.template
+++ b/cloud-config.sh.template
@@ -5,6 +5,13 @@ touch "${LOG}"
 chmod 0644 "${LOG}"
 echo "Running cloud init to attach AWS EIP" >> "${LOG}"
 
+currentscript="$0"
+
+# Function that is called when the script exits:
+function finish {
+    echo "Securely shredding ${currentscript}"; shred -u ${currentscript};
+}
+
 {
 # Hardening is causing this to be an issue
 # TODO: Find hardening rule that causes this issue
@@ -60,4 +67,5 @@ sudo AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} -u ec2-user /home/ec2-user/.local/
   --allocation-id eipalloc-abc123 2>&1 | tee -a "${LOG}"
 } 2>&1 >> "${LOG}"
 
-exit 0
+# Call the secure shred function to delete self because script contains RHN user and passwd
+trap finish EXIT


### PR DESCRIPTION
Need to add this back in to delete and shred the cloud init script because it contains the PEM due to the EIP requirements. I cannot upload the PEM as part of packer itself because packages must be installed, using the PEM, before the EIP can be attached and packer can access the system