### PR TITLE
Block quay init until the AMI reaches its final location

### DIFF
--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -52,11 +52,14 @@
     - name: Configure firewall ports
       become: true
       ansible.posix.firewalld:
-        port: "8443/tcp"
+        port: "{{ item }}"
         permanent: true
         immediate: true
         state: enabled
         zone: "public"
+      loop:
+        - "8443/tcp"
+        - "8080/tcp"
 
     - name: Pull OCP Dependencies
       become: true
@@ -188,6 +191,52 @@
       ansible.builtin.file:
         path: /etc/sysconfig/rh-quay-firstboot
         state: touch
+
+    - name: Create location for openshift docs pod to output logs
+      become: true
+      ansible.builtin.file:
+        path: /var/log/container
+        owner: ec2-user
+        group: ec2-user
+        mode: 0755
+        state: directory
+
+    - name: Create systemd unit file location for ec2-user
+      ansible.builtin.file:
+        path: /home/ec2-user/.config/systemd/user
+        state: directory
+
+    - name: Setup docs pod to run on system boot
+      containers.podman.podman_container:
+        name: openshift-docs
+        image: quay.io/danclark/openshift-docs:latest
+        log_options: path=/var/log/container/mycontainer.json
+        log_driver: k8s-file
+        state: present
+        recreate: yes
+        ports:
+          - "8443:8443"
+          - "8080:8080"
+        generate_systemd:
+          path: /home/ec2-user/.config/systemd/user/
+          restart_policy: always
+          time: 120
+          names: true
+          wants: network.target
+          after: network-online.target
+
+    - name: Reload systemd user services
+      ansible.builtin.systemd:
+        scope: user
+        daemon_reload: true
+
+    - name: Enable openshift-docs httpd systemd user service
+      ansible.builtin.systemd:
+        name: container-openshift-docs.service
+        state: started
+        enabled: true
+        masked: false
+        scope: user
 
     # Note: Should be able to install required roles this way but task usually fails
     # TODO: Determine why this task does not work correctly

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -180,7 +180,7 @@
 
     - name: Install python modules required by openshift4-aws-iso package
       ansible.builtin.pip:
-        requirements: /usr/share/openshift4-aws-iso/playbooks/requirements.txt
+        requirements: /usr/share/openshift4-aws-iso/requirements.txt
         extra_args: "--user"
 
     # Note: Should be able to install required roles this way but task usually fails

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -183,6 +183,12 @@
         requirements: /usr/share/openshift4-aws-iso/requirements.txt
         extra_args: "--user"
 
+    - name: Touch file to block quay init script from launching until AMI reaches final location
+      become: true
+      ansible.builtin.file:
+        path: /etc/sysconfig/rh-quay-firstboot
+        state: touch
+
     # Note: Should be able to install required roles this way but task usually fails
     # TODO: Determine why this task does not work correctly
     #- name: Install collections and roles for the openshift4-aws-iso package

--- a/cloud-config.sh.template
+++ b/cloud-config.sh.template
@@ -54,7 +54,7 @@ echo '*** Installing Base Dependencies... ***'
 # them twice
 sudo -u ec2-user pip3 install --user --upgrade pip
 sudo -u ec2-user pip3 install --user --upgrade wheel
-sudo -u ec2-user pip3 install --user --upgrade jinja2 awscli boto3 openshift jmespath packaging resolvelib
+sudo -u ec2-user pip3 install --user --upgrade jinja2 awscli boto3 openshift jmespath packaging resolvelib yq
 sudo -u ec2-user ansible-galaxy collection install --upgrade amazon.aws community.aws community.crypto containers.podman community.general ansible.posix community.kubernetes
 sudo -u ec2-user ansible-galaxy role install --force redhatofficial.rhel8_stig
 


### PR DESCRIPTION
The AMI will be transferred into a private AWS region where it will need to be modified with region specific settings. Because there are several transfers, we need to block the quay init first boot process from running until the AMI reaches the final location.

- Also fix error in location of python requirements file
- Also add yq to the list of python module dependencies installed on the AMI