### PR TITLE
Fix oc-mirror URL and improve error handling

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,12 @@ sudo dnf -y install packer
 sudo dnf install -y ansible-core
 ----
 
+. Install skopeo
++
+----
+sudo dnf install -y skopeo
+----
+
 == Building with packer
 
 . Download your pull secret from https://console.redhat.com/openshift/install/pull-secret

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -72,7 +72,7 @@
         - "{{ dev_uri }}/mirror-registry/latest/mirror-registry.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-install-linux-{{ ocp_max_ver }}.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-client-linux-{{ ocp_max_ver }}.tar.gz"
-        - "{{ mirror_uri }}/ocp/latest-4.11/oc-mirror.tar.gz"
+        - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/oc-mirror.tar.gz"
         - "{{ mirror_uri }}/pipeline/latest/tkn-linux-amd64.tar.gz"
 
       # Separate task because this doesn't come as an archive
@@ -102,7 +102,7 @@
         - "{{ dev_uri }}/mirror-registry/latest/mirror-registry.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-install-linux-{{ ocp_max_ver }}.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-client-linux-{{ ocp_max_ver }}.tar.gz"
-        - "{{ mirror_uri }}/ocp/latest-4.11/oc-mirror.tar.gz"
+        - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/oc-mirror.tar.gz"
         - "{{ mirror_uri }}/pipeline/latest/tkn-linux-amd64.tar.gz"
 
     - name: Change file ownership, group and permissions

--- a/build.sh
+++ b/build.sh
@@ -86,6 +86,21 @@ then
 fi
 
 ###########################################################################################################
+echo "Validating pull secret access to registry.redhat.io..."
+# login using existing credentials to registry, ignoring output.
+# Any prompt for input will get /dev/null which will fail login and return non-zero code.
+set +e
+skopeo login registry.redhat.io < /dev/null &> /dev/null
+if [ $? -eq 0 ]
+then
+  echo "Logged into registry.redhat.io successfully with provided pull secret"
+else
+  echo "ERROR: Pull secret file did not login to registry.redhat.io successfully"
+  exit 1
+fi
+set -e
+
+
 echo "Creating new imageset-config.yaml..."
 rm -f imageset-config.yaml.processed
 cp "${IMAGESET_CONFIG_TEMPLATE}"  imageset-config.yaml.processed

--- a/build.sh
+++ b/build.sh
@@ -164,7 +164,9 @@ if [[ "${PACKER_DEBUG}" == "true" ]]; then
   echo "PACKER WILL WRITE SSH KEYS TO WORKSPACE"
 fi
 
-
+echo "Running packer..."
 /usr/bin/packer build ${PACKER_ARGS} -machine-readable ${PACKER_TEMPLATE} | tee packer.log
 
+
+echo "Build completed successfully"
 exit 0

--- a/get_operator_versions.sh
+++ b/get_operator_versions.sh
@@ -7,6 +7,21 @@ IMG="registry.redhat.io/redhat/${INDEX}-operator-index:v${OCP_MAJ_VER}"
 
 echo IMG=${IMG}
 
+echo "Validating pull secret access to registry.redhat.io..."
+# login using existing credentials to registry, ignoring output.
+# Any prompt for input will get /dev/null which will fail login and return non-zero code.
+set +e
+skopeo login registry.redhat.io < /dev/null &> /dev/null
+if [ $? -eq 0 ]
+then
+  echo "Logged into registry.redhat.io successfully with provided pull secret"
+else
+  echo "ERROR: Pull secret file did not login to registry.redhat.io successfully"
+  exit 1
+fi
+set -e
+
+
 echo "Creating new imageset-config.yaml..."
 rm -f imageset-config.yaml.processed
 cp imageset-config.yaml imageset-config.yaml.processed


### PR DESCRIPTION
There is an error with oc-mirror latest-4.11. Switching to a version-specific URL seems to work.

Update the build script to validate the pull secret during the build using skopeo.

resolves #23
resolves #24 