### PR TITLE
Update pull secret verification and error logs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -96,6 +96,8 @@ then
   echo "Logged into registry.redhat.io successfully with provided pull secret"
 else
   echo "ERROR: Pull secret file did not login to registry.redhat.io successfully"
+  echo "Pull secret contains credentials for the following registries:"
+  echo "$(jq -r '.auths | keys[]' ${PULL_SECRET})"
   exit 1
 fi
 set -e
@@ -109,11 +111,13 @@ for op in $(yq -r '.mirror.operators[0].packages[].name' imageset-config.yaml.pr
 do
   echo "Processing operator: ${op}..."
 
+  echo "  getting default channel name..."
   DEF_CHANNEL=$(oc-mirror list operators \
                   --catalog=${CATALOG_IMG} \
                   --package=${op} \
                   | grep -A 1 'DEFAULT CHANNEL' | tail -1 | awk '{print $NF}')
 
+  echo "  getting latest version from channel..."
   LATEST_VER=$(oc-mirror list operators \
                  --catalog=${CATALOG_IMG} --package=${op} \
                  --channel=${DEF_CHANNEL} 2>/dev/null | grep -v VERSIONS | tail -1)

--- a/build.sh
+++ b/build.sh
@@ -90,10 +90,10 @@ echo "Validating pull secret access to registry.redhat.io..."
 # login using existing credentials to registry, ignoring output.
 # Any prompt for input will get /dev/null which will fail login and return non-zero code.
 set +e
-skopeo login registry.redhat.io < /dev/null &> /dev/null
+skopeo inspect docker://${CATALOG_IMG} > /dev/null
 if [ $? -eq 0 ]
 then
-  echo "Logged into registry.redhat.io successfully with provided pull secret"
+  echo "Verified registry credentials to registry.redhat.io successfully"
 else
   echo "ERROR: Pull secret file did not login to registry.redhat.io successfully"
   echo "Pull secret contains credentials for the following registries:"

--- a/get_operator_versions.sh
+++ b/get_operator_versions.sh
@@ -11,10 +11,10 @@ echo "Validating pull secret access to registry.redhat.io..."
 # login using existing credentials to registry, ignoring output.
 # Any prompt for input will get /dev/null which will fail login and return non-zero code.
 set +e
-skopeo login registry.redhat.io < /dev/null &> /dev/null
+skopeo inspect docker://${CATALOG_IMG} > /dev/null
 if [ $? -eq 0 ]
 then
-  echo "Logged into registry.redhat.io successfully with provided pull secret"
+  echo "Verified registry credentials to registry.redhat.io successfully"
 else
   echo "ERROR: Pull secret file did not login to registry.redhat.io successfully"
   echo "Pull secret contains credentials for the following registries:"

--- a/get_operator_versions.sh
+++ b/get_operator_versions.sh
@@ -17,6 +17,8 @@ then
   echo "Logged into registry.redhat.io successfully with provided pull secret"
 else
   echo "ERROR: Pull secret file did not login to registry.redhat.io successfully"
+  echo "Pull secret contains credentials for the following registries:"
+  echo "$(jq -r '.auths | keys[]' ${PULL_SECRET})"
   exit 1
 fi
 set -e
@@ -30,11 +32,13 @@ for op in $(yq -r '.mirror.operators[0].packages[].name' imageset-config.yaml)
 do
   echo "Processing operator: ${op}..."
 
+  echo "  getting default channel name..."
   DEF_CHANNEL=$(oc-mirror list operators \
                   --catalog=${IMG} \
                   --package=${op} \
                   | grep -A 1 'DEFAULT CHANNEL' | tail -1 | awk '{print $NF}')
 
+  echo "  getting latest version from channel..."
   LATEST_VER=$(oc-mirror list operators \
                  --catalog=${IMG} --package=${op} \
                  --channel=${DEF_CHANNEL} 2>/dev/null | grep -v VERSIONS | tail -1)


### PR DESCRIPTION
Changed verification of pull secret creds by inspecting the catalog image.

Example of success logs:

```
Validating pull secret access to registry.redhat.io...
Verified registry credentials to registry.redhat.io successfully
```

Example of failure logs:

```
Validating pull secret access to registry.redhat.io...
time="2023-04-21T18:12:53Z" level=fatal msg="Error parsing image name \"docker://registry.redhat.io/redhat/redhat-operator-index:v4.12\": unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication"
ERROR: Pull secret file did not login to registry.redhat.io successfully
Pull secret contains credentials for the following registries:
localhost:8443
```

The skopeo inspect of this image takes about 35 seconds on my local machine.