### PR TITLE
Add dependency operators for cluster-logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 packer.log
 .oc-mirror.log
 *.log
-imageset-config.yaml.processed
+imageset-config.yaml.processed*
 imageset-config.yaml.new
 cloud-config.sh
 rh-cdn.pem
 *.pem
+.vscode/

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -38,6 +38,8 @@
           - git
           - vim
           - jq
+          - tmux
+          - bash-completion
           - mlocate
           - pigz
 
@@ -83,6 +85,21 @@
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/openshift-client-linux-{{ ocp_max_ver }}.tar.gz"
         - "{{ mirror_uri }}/ocp/{{ ocp_max_ver }}/oc-mirror.tar.gz"
         - "{{ mirror_uri }}/pipeline/latest/tkn-linux-amd64.tar.gz"
+
+    - name: Generate oc bash completion file
+      ansible.builtin.shell:
+        cmd: /usr/local/bin/oc completion bash > /etc/bash_completion.d/oc
+        creates: /etc/bash_completion.d/oc
+      become: true
+
+    - name: Set permissions on oc bash completion file
+      ansible.builtin.file:
+        path: /etc/bash_completion.d/oc
+        owner: root
+        group: root
+        mode: '0644'
+        state: file
+      become: true
 
     - name: Change file ownership, group and permissions
       become: true

--- a/imageset-config.yaml
+++ b/imageset-config.yaml
@@ -25,11 +25,22 @@ mirror:
           channels:
             - name: compliance-operator-CHANNEL
               minVersion: compliance-operator-VERSION
+        - name: elasticsearch-operator
+          channels:
+            - name: elasticsearch-operator-CHANNEL
+              minVersion: elasticsearch-operator-VERSION
         - name: file-integrity-operator
           channels:
             - name: file-integrity-operator-CHANNEL
               minVersion: file-integrity-operator-VERSION
+        - name: loki-operator
+          channels:
+            - name: loki-operator-CHANNEL
+              minVersion: loki-operator-VERSION
         - name: rhsso-operator
           channels:
             - name: rhsso-operator-CHANNEL
               minVersion: rhsso-operator-VERSION
+  additionalimages:
+    # rhscl/postgresql-10-rhel7 is required by the rhsso-operator
+    - name: registry.redhat.io/rhscl/postgresql-10-rhel7:1-173

--- a/quayinit.sh
+++ b/quayinit.sh
@@ -50,6 +50,10 @@ echo "$(date) : Importing local content archive into quay mirror registry..." >>
 
 /usr/local/bin/oc-mirror --from /home/ec2-user/archives/mirror_seq1_000000.tar docker://${HOSTNAME}:8443 | tee -a "${LOG_FILE}"
 
+# set file permissions of release-signatures to be world readable
+echo "$(date) : Set file permissions of release signatures..." >> "${LOG_FILE}"
+chmod -v 644 /oc-mirror-workspace/results-*/release-signatures/signature-sha256-*.json | tee -a "${LOG_FILE}"
+
 echo "$(date) : Completed import of local content archive" >> "${LOG_FILE}"
 
 # Ensure quay init does not run again


### PR DESCRIPTION
* Added elasticsearch-operator and loki-operator since they are required by cluster-logging
* Added postgresql image that is required for RHSSO operator
* Fixed the file permissions of the release-signatures file to be world readable.
* Added bash-completion for oc command

resolves #29 
resolves #30 