### PR TITLE
Remove --continue-on-error flag to ensure mirror integrity

### DIFF
--- a/aws-rhel8-quay.json
+++ b/aws-rhel8-quay.json
@@ -162,7 +162,7 @@
         "set -ex",
         "mkdir -p ${XDG_RUNTIME_DIR}/containers || true",
         "cat /tmp/pull-secret.txt > ${XDG_RUNTIME_DIR}/containers/auth.json",
-        "/usr/local/bin/oc-mirror --config /home/ec2-user/imageset-config.yaml --continue-on-error file://archives || true"
+        "/usr/local/bin/oc-mirror --config /home/ec2-user/imageset-config.yaml file://archives"
       ]
     },
     {


### PR DESCRIPTION
If errors occur during mirror to disk, they could cause errors for images loading into the registry, which prevents a user from being able to install a cluster. Instead, we should fail a build if the mirror to disk doesn't work for some reason.

resolves #35 